### PR TITLE
fix: use correct token when pushing to protected branches

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -46,6 +46,8 @@ jobs:
 
       - id: push-changelog
         if: github.ref_protected
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTOMATION_REPO_TOKEN }}
         run: |
           : Push Changelog
           set -e


### PR DESCRIPTION
The supplied GITHUB_TOKEN never has authority to force a push to a
protected branch.  We must use a PAT with the correct authority.

Fixes: #27