### PR TITLE
fix: do not pass secret to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body_path: CHANGELOG.md
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - id: tag
         run: |


### PR DESCRIPTION
Does not look to be required for this 3rd party action.

Fixes: #44